### PR TITLE
Changing incorrect prop name `siblingSize` to `siblingsSize` in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import { usePaginated } from '@makotot/paginated'
 
 ...
 
-const { pages, currentPage, hasPrev, hasNext, getFirstBoundary, getLastBoundary, isPrevTruncated, isNextTruncated } = usePaginated({ currentPage: 1, totalPage: 10, siblingSize: 2, boundarySize: 2 });
+const { pages, currentPage, hasPrev, hasNext, getFirstBoundary, getLastBoundary, isPrevTruncated, isNextTruncated } = usePaginated({ currentPage: 1, totalPage: 10, siblingsSize: 2, boundarySize: 2 });
 
 return (
   <div>
@@ -101,7 +101,7 @@ Type: `number`
 
 The value of total page. Required.
 
-### `siblingSize`
+### `siblingsSize`
 
 Type: `number`
 


### PR DESCRIPTION
Hi there!

I noticed that the example provided in the docs with the hooks doesn't work. Apparently, incorrect `siblingSize` property is used  instead of `siblingsSize`. I've simply changed the Readme.

Let me know if I can do anything else.
Thanks